### PR TITLE
Cookie Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 env.php
 .DS_Store
+cookies.json

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # TikTok Scraper in PHP
 
-`Status: Work in progress.`
-
 ```
 By default, this scraper will attempt to use NodeJS to sign the URL. If you do not have node installed, it will attempt to install it during the composer install step. If you do, it will simply find the path to it. If you'd like to change this logic, you can read more below about setting your signMethod => 'datafetch', an API I have created for signing tiktok urls.
 ```
+
+# `v1.8.0` Breaking Change
+
+In `v1.8.0`, the scraper now sets cookies by default, which means that you must provide writable permissions for a `cookies.json` file, and then set it in the configuration (see example config below).
+
+Need to disable cookies? Set `'disableCookies' => true` in the configuration. See example below.
 
 ## Installation
 
@@ -30,7 +34,13 @@ $scraper = new Scraper([
     'address' => '127.0.0.1:8080',
     'auth' => 'username:password'
   ],
-  'timeout' => 20
+  'timeout' => 20,
+
+  // Since v1.8.0 (Must set cookie file)
+  'cookieFile' => __DIR__ . '/cookies.json'
+
+  // If not using cookies:
+  'disableCookies' => true
 ]);
 ```
 

--- a/examples/session.php
+++ b/examples/session.php
@@ -6,30 +6,13 @@ require_once __DIR__ . '/../src/TikTok.php';
 /**
  * Get development config
  */
-// config = require_once __DIR__ . '/env.php';
+$config = require_once __DIR__ . '/env.php';
 
 use TikTok\Scraper;
 
 // Instantiate TikTok Scraper library
-$scraper = new Scraper([
-  'verbose' => true
-]);
+$scraper = new Scraper($config);
 
-
-/**
- * Running the following generates a webid and session id
- * on TikTok's servers. I'm still working on figuring out
- * what this means. All I've found at the moment is if you generate
- * it once, the rate limiting / verification slows down.
- *
- * However, if you attempt to re-generate it again, you end up
- * receiving a 405 error afterwards. It seems to me they log
- * the ip when registering this. Will look further.
- */
-$scraper
-  ->session
-  ->webid()
-  ->ssid();
 
 // Call after the webid and ssid has been generated on tiktok
 $data = $scraper->user->videos('iratee', 10);

--- a/src/TikTok/Core/Libraries/CookieJar.php
+++ b/src/TikTok/Core/Libraries/CookieJar.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace TikTok\Core\Libraries;
+
+/**
+ * Responsible for Cookie handling.
+ */
+class CookieJar {
+
+  /**
+   * Instance configuration object
+   */
+  private $config = false;
+
+  /**
+   * Class constructor
+   */
+  public function __construct ($config = null) {
+
+    // Set config by default
+    $this->config = (object) [];
+
+    // If config is passed, set the class config object.
+    if (!is_null($config)) $this->config = $config;
+
+    // Are cookies disabled?
+    if (isset($this->config->disableCookies))
+      if ($this->config->disableCookies === true) return;
+
+    // Make sure the cookie file is set.
+    if (!isset($this->config->cookieFile))
+      throw new \Exception('No cookie file provided in config. Please set `cookieFile` (See documentation).');
+
+    // Make sure cookie file is readable.
+    if (isset($this->config->cookieFile))
+      if (!$this->isReadable()) throw new \Exception('Unable to read cookie file.');
+  }
+
+  /**
+   * Responsible for getting the contents of the cookie
+   * file.
+   * @return ArrayObject
+   */
+  public function contents () {
+    if ($this->isReadable()) {
+      try {
+        $contents = file_get_contents($this->config->cookieFile);
+
+        if (empty($contents)) return false;
+
+        $data = json_decode($contents);
+        return $data;
+      } catch (\Exception $e) {
+        throw new \Exception($e->getMessage());
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Responsible for writing to the cookie file.
+   * @param  array $data
+   * @return boolean
+   */
+  public function write ($data) {
+    if ($this->isWritable()) {
+      try {
+        $formattedData = json_encode($data);
+        file_put_contents($this->config->cookieFile, $formattedData);
+        return true;
+      } catch (\Exception $e) {
+        return false;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Check if the cookie file exists
+   * @return boolean
+   */
+  private function exists () {
+    if (!isset($this->config->cookieFile)) return false;
+    if (file_exists($this->config->cookieFile)) return true;
+    return false;
+  }
+
+  /**
+   * Check if the cookie file is readable
+   * @return boolean
+   */
+  private function isReadable () {
+    if (!$this->exists()) return false;
+    if (is_readable($this->config->cookieFile)) return true;
+    return false;
+  }
+
+  /**
+   * Check if the cookie file is writable.
+   * @return boolean
+   */
+  private function isWritable () {
+    if (!$this->exists()) return false;
+    if (is_writable($this->config->cookieFile)) return true;
+    return false;
+  }
+
+}

--- a/src/TikTok/Core/Libraries/Request.php
+++ b/src/TikTok/Core/Libraries/Request.php
@@ -65,11 +65,25 @@ class Request {
 
   public function call ($endpoint, $customHeaders = []) {
 
-    // Get the saved cookies from cookie jar
-    $savedCookies = $this->savedCookies();
+    if (!isset($this->config->disableCookies)) {
 
-    // If there are any saved cookies, set them as a header.
-    if ($savedCookies) $customHeaders[] = 'Cookie: ' . rtrim($savedCookies);
+      // Get the saved cookies from cookie jar
+      $savedCookies = $this->savedCookies();
+
+      // If there are any saved cookies, set them as a header.
+      if ($savedCookies) $customHeaders[] = 'Cookie: ' . rtrim($savedCookies);
+
+    } else {
+
+      // If disable cookies is set, but is not true.
+      if ($this->config->disableCookies !== true) {
+        // Get the saved cookies from cookie jar
+        $savedCookies = $this->savedCookies();
+
+        // If there are any saved cookies, set them as a header.
+        if ($savedCookies) $customHeaders[] = 'Cookie: ' . rtrim($savedCookies);
+      }
+    }
 
     // Grab headers that will be used based on endpoint
     $headers = $this->getHeaders($endpoint);

--- a/src/TikTok/Core/Libraries/Request.php
+++ b/src/TikTok/Core/Libraries/Request.php
@@ -25,7 +25,23 @@ class Request {
    */
   private $endpoints = false;
 
+  /**
+   * Post Parameters to be passed via CURL
+   * @var array
+   */
   private $postParams = false;
+
+  /**
+   * Cookies from response
+   * @var array
+   */
+  private $cookies = [];
+
+  /**
+   * CookieJar class
+   * @var Tiktok\Core\Libraries\CookieJar
+   */
+  public $cookieJar = null;
 
   /**
    * Class construction
@@ -37,6 +53,9 @@ class Request {
 
     // Set the endpoints instance
     $this->endpoints = $endpoints;
+
+    // Set the cookiejar file.
+    $this->cookieJar = new \TikTok\Core\Libraries\CookieJar($this->config);
   }
 
   public function setPostParams ($params = false) {
@@ -46,9 +65,11 @@ class Request {
 
   public function call ($endpoint, $customHeaders = []) {
 
-    if (isset($this->config->cookie)) {
-      $customHeaders[] = 'Cookie: ' . $this->config->cookie;
-    }
+    // Get the saved cookies from cookie jar
+    $savedCookies = $this->savedCookies();
+
+    // If there are any saved cookies, set them as a header.
+    if ($savedCookies) $customHeaders[] = 'Cookie: ' . rtrim($savedCookies);
 
     // Grab headers that will be used based on endpoint
     $headers = $this->getHeaders($endpoint);
@@ -115,6 +136,7 @@ class Request {
 
     // Merge any custom headers with the fetched headers from Endpoints
     curl_setopt($ch, CURLOPT_HTTPHEADER, array_merge($headers, $customHeaders));
+    curl_setopt($ch, CURLOPT_HEADERFUNCTION, array($this, 'getCookies') );
 
     // Get the response
     $response = curl_exec($ch);
@@ -129,6 +151,8 @@ class Request {
           'headers' => $headers,
           'endpoint' => $endpoint
         ]);
+
+        print_r($this->cookies);
       }
     }
 
@@ -182,10 +206,52 @@ class Request {
 	}
 
   /**
+   * Checks the cookie jar for a valid
+   * dataset, then formats the cookie string.
+   *
+   * @return string
+   */
+  public function savedCookies () {
+    $cookieString = '';
+    $cookieData = $this->cookieJar->contents();
+
+    // Validation
+    if (!$cookieData) return false;
+
+    // Iterate through each and add it to the string.
+    foreach ($cookieData as $c) {
+      $parts = explode(';', $c);
+      $cookieString .= $parts[0] . '; ';
+    }
+
+    return $cookieString;
+  }
+
+  private function getCookies ($ch, $headerLine) {
+    if (strpos($headerLine, 'set-cookie:') !== false)
+      $cookie = str_replace('set-cookie: ', '', $headerLine);
+    if (strpos($headerLine, 'Set-Cookie:') !== false)
+      $cookie = str_replace('Set-Cookie: ', '', $headerLine);
+
+    if (isset($cookie)) array_push($this->cookies, $cookie);
+
+    return strlen($headerLine);
+  }
+
+  /**
    * Simply returns the data variable.
    */
   public function response () {
     return $this->data;
+  }
+
+  /**
+   * Saves cookies from the last request.
+   * @return boolean
+   */
+  public function saveCookies () {
+    if ($this->cookieJar->write($this->cookies)) return true;
+    return false;
   }
 
   /**

--- a/src/TikTok/Core/Resources/Endpoints.php
+++ b/src/TikTok/Core/Resources/Endpoints.php
@@ -53,7 +53,10 @@ class Endpoints {
       'hashtag-data' => 'https://www.tiktok.com/tag/{hashtag}?pageType=6',
 
       // Music
-      'music-data'   => 'https://www.tiktok.com/music/{slug}'
+      'music-data'   => 'https://www.tiktok.com/music/{slug}',
+
+      // Web
+      'home'   => 'https://www.tiktok.com/'
     ],
 
     'm' => [

--- a/src/TikTok/Requests/SessionRequests.php
+++ b/src/TikTok/Requests/SessionRequests.php
@@ -26,6 +26,16 @@ class SessionRequests
   }
 
   /**
+   * Call the homepage of TikTok to get the set-cookie
+   * headers so it can be saved to the cookie jar.
+   */
+  public function initialCall () {
+    echo "called";
+    $endpoint = $this->instance->endpoints->get('web.home');
+    $this->instance->request->call($endpoint)->saveCookies();
+  }
+
+  /**
    * @EXPERIMENTAL: Get SessionId
    */
   public function ssid () {
@@ -51,6 +61,8 @@ class SessionRequests
    * @EXPERIMENTAL: Get webid
    */
   public function webid () {
+    if ($this->instance->request->savedCookies()) return $this;
+
     $endpoint = $this->instance->endpoints->get('web.web-id');
 
     // Send a request to the api responsible for setting web id
@@ -64,11 +76,7 @@ class SessionRequests
         'user_unique_id' => ''
       ])
       ->call($endpoint)
-      ->response();
-
-    $this->webId = isset($res->web_id) ? $res->web_id : false;
-
-    $this->instance->request->webId = $this->webId;
+      ->saveCookies();
 
     return $this;
   }

--- a/src/TikTok/Requests/SessionRequests.php
+++ b/src/TikTok/Requests/SessionRequests.php
@@ -30,7 +30,6 @@ class SessionRequests
    * headers so it can be saved to the cookie jar.
    */
   public function initialCall () {
-    echo "called";
     $endpoint = $this->instance->endpoints->get('web.home');
     $this->instance->request->call($endpoint)->saveCookies();
   }

--- a/src/TikTok/Scraper.php
+++ b/src/TikTok/Scraper.php
@@ -91,7 +91,6 @@ class Scraper
     $this->music = new \TikTok\Requests\MusicRequests($this);
 
     /**
-     * @Experimental
      * Instantiate the session requests class
      */
     $this->session = new \TikTok\Requests\SessionRequests($this);
@@ -101,6 +100,26 @@ class Scraper
      * Captcha library
      */
     $this->captcha = new \TikTok\Core\Libraries\Captcha($this);
+
+
+    /**
+     * Cookie Initialization
+     */
+    $useCookies = true;
+
+    // Are cookies disabled in the config?
+    if (isset($this->config->disableCookies)) {
+      if ($this->config->disableCookies === true) {
+        $useCookies = false;
+      }
+    }
+
+    // If using cookies, check for saved cookies. If not, get them.
+    if ($useCookies === true) {
+      if (!$this->request->savedCookies()) {
+        $this->session->initialCall();
+      }
+    }
   }
 
 
@@ -152,6 +171,7 @@ class Scraper
     $this->config->datafetchApiKey = null;
 
     if (!is_null($config)) {
+
       if (!is_array($config)) return false;
 
       foreach ($config as $key => $val) {
@@ -167,9 +187,6 @@ class Scraper
    */
   public function set ($var, $val) {
     $this->config->{$var} = $val;
-
-    // Re initialize
-    $this->_initialize();
   }
 
   // Set an error


### PR DESCRIPTION
# Cookie Handling

The scraper now stores cookies by default. This means that we have reached a new breaking version change, labeled `v1.8.0`. As of this version, you must provide a file with read and write permissions, and pass it to the scraper as a `cookieFile` configuration variable. Please look below for an example:

```
new Scraper([
  'cookieFile' => __DIR__ . '/cookies.json'
]);
```

In the above example. `cookies.json` would have readable and writable permissions set.

-------------------------

# Disabling Cookies 

If you are able to disable cookies having to be saved, you can do so by setting the following:

```
new Scraper([
  'disableCookies' => true
]);
```

-------------------------

## Why are cookies being saved by default?

Because recently, TikTok has locked down their web routes to require cookies for `tt_webid` and `tt_webid_v2` to be set. Constant access to these said routes will result in captcha responses if not handled correctly.